### PR TITLE
[UNFLO-502] Fix openScreen

### DIFF
--- a/android/src/main/java/com/unflow/reactnative/CurrentActivityProvider.kt
+++ b/android/src/main/java/com/unflow/reactnative/CurrentActivityProvider.kt
@@ -1,0 +1,13 @@
+package com.unflow.reactnative
+
+import android.app.Activity
+import com.unflow.androidsdk.ui.activity.ActivityProvider
+
+internal class CurrentActivityProvider(
+    private val getCurrentActivity: () -> Activity?
+) : ActivityProvider {
+
+    override fun getActivity(): Activity? {
+        return getCurrentActivity()
+    }
+}

--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -39,7 +39,7 @@ class UnflowModule(
     @ReactMethod
     fun setAttributes(attributes: ReadableMap) {
       val attributesMap = attributes.toHashMap() as? Map<String, Any>
-      val stringAttributes = attributesMap?.filterMapValueType(String::class)
+      val stringAttributes = attributesMap?.filterValues { it is String } as? Map<String, String>
       if (stringAttributes != null) {
         UnflowSdk.client().setAttributes(attributes = stringAttributes)
       }
@@ -76,8 +76,4 @@ class UnflowModule(
       if (!hasKey(key)) return null
       return reactContext.resources.getIdentifier(getString(key), "font", reactContext.packageName)
     }
-}
-
-private inline fun <K, V, reified T : Any> Map<K, V>.filterMapValueType(type: KClass<T>): Map<K, T> {
-  return filterValues { type.isInstance(it) }.mapValues { type.cast(it) }
 }

--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import com.facebook.react.bridge.*
 import com.unflow.androidsdk.UnflowSdk
 import com.unflow.androidsdk.ui.theme.Fonts
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 
 class UnflowModule(
   private val reactContext: ReactApplicationContext,
@@ -33,11 +35,13 @@ class UnflowModule(
       UnflowSdk.client().setUserId(userId = userId)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @ReactMethod
     fun setAttributes(attributes: ReadableMap) {
-      val mappedAttributes = attributes.toHashMap() as? Map<String, String>
-      if (mappedAttributes != null) {
-        UnflowSdk.client().setAttributes(attributes = mappedAttributes)
+      val attributesMap = attributes.toHashMap() as? Map<String, Any>
+      val stringAttributes = attributesMap?.filterMapValueType(String::class)
+      if (stringAttributes != null) {
+        UnflowSdk.client().setAttributes(attributes = stringAttributes)
       }
     }
 
@@ -60,12 +64,20 @@ class UnflowModule(
 
     @ReactMethod
     fun trackEvent(eventName: String, metadata: ReadableMap) {
-      val mappedMetadata = metadata.toHashMap() as Map<String, Any?>
-      UnflowSdk.client().trackEvent(eventName, mappedMetadata)
+      val mappedMetadata = metadata.toHashMap() as? Map<String, Any?>
+      if (mappedMetadata != null) {
+        UnflowSdk.client().trackEvent(eventName, mappedMetadata)
+      } else {
+        UnflowSdk.client().trackEvent(eventName)
+      }
     }
 
     private fun ReadableMap.getFontResId(key: String): Int? {
       if (!hasKey(key)) return null
       return reactContext.resources.getIdentifier(getString(key), "font", reactContext.packageName)
     }
+}
+
+private inline fun <K, V, reified T : Any> Map<K, V>.filterMapValueType(type: KClass<T>): Map<K, T> {
+  return filterValues { type.isInstance(it) }.mapValues { type.cast(it) }
 }

--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -1,15 +1,16 @@
 package com.unflow.reactnative
 
-import android.app.Application
-import com.facebook.react.bridge.*
+import android.util.Log
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
 import com.unflow.androidsdk.UnflowSdk
+import com.unflow.androidsdk.ui.activity.CurrentActivityProvider
 import com.unflow.androidsdk.ui.theme.Fonts
-import kotlin.reflect.KClass
-import kotlin.reflect.cast
 
 class UnflowModule(
   private val reactContext: ReactApplicationContext,
-  private val application: Application,
 ) : ReactContextBaseJavaModule(reactContext) {
 
     override fun getName(): String {
@@ -18,10 +19,17 @@ class UnflowModule(
 
     @ReactMethod
     fun initialize(apiKey: String, enableLogging: Boolean) {
+      val application = currentActivity?.application
+      if (application == null) {
+        Log.e("UNFLOW", "Unable to initialize Unflow as we have no activity :(")
+        return
+      }
       UnflowSdk.initialize(
         application = application,
         config = UnflowSdk.Config(apiKey, enableLogging),
-        analyticsListener = null
+        analyticsListener = null,
+        // TODO: Enable this once we have published 1.2.2
+//        activityProvider = CurrentActivityProvider { currentActivity }
       )
     }
 
@@ -58,7 +66,7 @@ class UnflowModule(
     }
 
     @ReactMethod
-    fun openScreen(screenId: Double) {
+    fun openScreen(screenId: Int) {
       UnflowSdk.client().openScreen(screenId = screenId.toLong())
     }
 

--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -1,10 +1,14 @@
 package com.unflow.reactnative
 
+import android.app.Application
 import com.facebook.react.bridge.*
 import com.unflow.androidsdk.UnflowSdk
 import com.unflow.androidsdk.ui.theme.Fonts
 
-class UnflowModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+class UnflowModule(
+  private val reactContext: ReactApplicationContext,
+  private val application: Application,
+) : ReactContextBaseJavaModule(reactContext) {
 
     override fun getName(): String {
         return "Unflow"
@@ -12,7 +16,6 @@ class UnflowModule(private val reactContext: ReactApplicationContext) : ReactCon
 
     @ReactMethod
     fun initialize(apiKey: String, enableLogging: Boolean) {
-      val application = currentActivity!!.application
       UnflowSdk.initialize(
         application = application,
         config = UnflowSdk.Config(apiKey, enableLogging),

--- a/android/src/main/java/com/unflow/reactnative/UnflowReactNativePackage.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowReactNativePackage.kt
@@ -1,15 +1,14 @@
 package com.unflow.reactnative
 
-import android.app.Application
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
-class UnflowReactNativePackage(private val application: Application) : ReactPackage {
+class UnflowReactNativePackage : ReactPackage {
 
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(UnflowModule(reactContext, application))
+        return listOf(UnflowModule(reactContext))
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/android/src/main/java/com/unflow/reactnative/UnflowReactNativePackage.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowReactNativePackage.kt
@@ -1,14 +1,15 @@
 package com.unflow.reactnative
 
+import android.app.Application
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
-class UnflowReactNativePackage : ReactPackage {
+class UnflowReactNativePackage(private val application: Application) : ReactPackage {
 
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(UnflowModule(reactContext))
+        return listOf(UnflowModule(reactContext, application))
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/example/android/app/src/main/java/com/unflow/reactnativeexample/MainApplication.java
+++ b/example/android/app/src/main/java/com/unflow/reactnativeexample/MainApplication.java
@@ -27,7 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for UnflowReactNativeExample:
           // packages.add(new MyReactNativePackage());
-          packages.add(new UnflowReactNativePackage());
+          packages.add(new UnflowReactNativePackage(getApplication()));
           return packages;
         }
 

--- a/example/android/app/src/main/java/com/unflow/reactnativeexample/MainApplication.java
+++ b/example/android/app/src/main/java/com/unflow/reactnativeexample/MainApplication.java
@@ -1,16 +1,15 @@
 package com.unflow.reactnativeexample;
 
 import android.app.Application;
-import android.content.Context;
+
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.ReactInstanceManager;
 import com.facebook.soloader.SoLoader;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import com.unflow.reactnative.UnflowReactNativePackage;
+
+import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -27,7 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for UnflowReactNativeExample:
           // packages.add(new MyReactNativePackage());
-          packages.add(new UnflowReactNativePackage(getApplication()));
+          packages.add(new UnflowReactNativePackage());
           return packages;
         }
 


### PR DESCRIPTION
Seems like we register the lifecycle activity provider too late on React Native and miss the first (main) Activity.

Fix the navigator by implementing a new kind of `ActivityProvider` for React Native – `CurrentActivityProvider` – and passing that as an argument to the initialize function in the Unflow SDK.