### PR TITLE
Fix old package name reference

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.unflow.reactnativesdk" />
+<manifest package="com.unflow.reactnative" />


### PR DESCRIPTION
Follow on from missing package name in https://github.com/unflowhq/unflow-react-native-sdk/pull/16