### PR TITLE
Pin version on iOS

### DIFF
--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name = "unflow-react-native"
-  s.version = "1.5.1"
+  s.version = package["version"]
   s.summary = package["description"]
   s.homepage = package["homepage"]
   s.license = package["license"]


### PR DESCRIPTION
Made a mistake in the last release. The version in this Podspec should always match that of the `package.json` because it is for the React Native wrapper pod `unflow-react-native` and not the standard `Unflow` pod. This is linked via `s.dependency "Unflow"` and always uses the latest version unless explicitly specified using `~> x.x.x`