### PR TITLE
Pin explicit version of native SDK

### DIFF
--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Unflow"
+  s.dependency "Unflow", :git => "https://github.com/unflowhq/unflow-ios-sdk", :tag => "v1.6.2"
 end


### PR DESCRIPTION
We should pin the version of the native SDK used when integrating a specific React Native version. Previously it would always update itself to the latest