### PR TITLE
Use correct podspec syntax

### DIFF
--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Unflow", :git => "https://github.com/unflowhq/unflow-ios-sdk", :tag => "v1.6.2"
+  s.dependency "Unflow", "1.6.2"
 end


### PR DESCRIPTION
Fix for https://github.com/unflowhq/unflow-react-native-sdk/pull/40. Seeing this error otherwise:
```
[!] Failed to load 'unflow-react-native' podspec:
[!] Invalid `unflow-react-native.podspec` file: [!] Podspecs cannot specify the source of dependencies. The `:git` option is not supported. `:git` can be used in the Podfile instead to override global dependencies
```