### PR TITLE
Improve custom fonts lookup

### DIFF
--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -123,6 +123,11 @@ class UnflowModule(
 
     private fun ReadableMap.getFontResId(key: String): Int? {
       if (!hasKey(key)) return null
-      return reactContext.resources.getIdentifier(getString(key), "font", reactContext.packageName)
+
+      val fontId = reactContext.resources.getIdentifier(getString(key), "font", reactContext.packageName)
+      if (fontId != 0) return fontId
+
+      val fontsId = reactContext.resources.getIdentifier(getString(key), "fonts", reactContext.packageName)
+      return if (fontsId != 0) fontsId else null
     }
 }


### PR DESCRIPTION
- Unflow assumed that the necessary custom fonts lived in the `src/main/res/font` folder, as is the convention on Android
- This [popular blog posts](https://mehrankhandev.medium.com/ultimate-guide-to-use-custom-fonts-in-react-native-77fcdf859cf4) uses the `fonts` directory which is where most RN apps have their fonts as a result
- This change does two things:
1. Looks in both the `font` and `fonts` directory for custom font files
2. Because the `getIdentifier` returns `0` when the font isn't found a runtime error occurred. We've fixed this by returning `null` if the font is not found in either directory