### PR TITLE
Filter openers for space

### DIFF
--- a/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
+++ b/android/src/main/java/com/unflow/reactnative/UnflowModule.kt
@@ -6,6 +6,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEm
 import com.unflow.androidsdk.UnflowSdk
 import com.unflow.androidsdk.ui.theme.Fonts
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collectLatest
 
 class UnflowModule(
   private val reactContext: ReactApplicationContext,
@@ -102,7 +103,7 @@ class UnflowModule(
     @ReactMethod
     fun openers(spaceKey: String) {
       val job = scope.launch {
-        UnflowSdk.client().openers(spaceKey = spaceKey).collect {
+        UnflowSdk.client().openers(spaceKey = spaceKey).collectLatest {
           val openerList = WritableNativeArray()
 
           it.forEach {
@@ -129,7 +130,7 @@ class UnflowModule(
     @ReactMethod
     fun spaces() {
       val job = scope.launch {
-        UnflowSdk.client().spaces().collect {
+        UnflowSdk.client().spaces().collectLatest {
           val spaceList = Arguments.createArray()
 
           it.forEach {

--- a/src/opener-view.tsx
+++ b/src/opener-view.tsx
@@ -16,7 +16,7 @@ const OpenerView: React.FC<UnflowOpenerViewType> = ({
 
   let onOpenersChanged = useCallback(
     (event: NativeOpenerChangedEvent) => {
-      setOpeners(event[spaceKey] || []);
+      if (event[spaceKey]) setOpeners(event[spaceKey]);
     },
     [spaceKey]
   );
@@ -43,7 +43,7 @@ const useSpace = (spaceKey: string = 'default') => {
 
   let onOpenersChanged = useCallback(
     (event: NativeOpenerChangedEvent) => {
-      setOpeners(event[spaceKey] || []);
+      if (event[spaceKey]) setOpeners(event[spaceKey]);
     },
     [spaceKey]
   );


### PR DESCRIPTION
React Native events cannot be scoped in any way. Which means the callback will fire for every listener regardless of if the event is relevant to the particular space. This change skips the callback if it is for a different space, rather than resetting the openers to `[]`