### PR TITLE
v1.11.1

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -353,7 +353,7 @@ PODS:
   - RNSVG (12.3.0):
     - React-Core
   - Unflow (1.11.0)
-  - unflow-react-native (1.11.0):
+  - unflow-react-native (1.11.1):
     - React-Core
     - Unflow (= 1.11.0)
   - Yoga (1.14.0)
@@ -563,7 +563,7 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Unflow: c0d7fb1b982257082a47ffd32f2e301fb398cebc
-  unflow-react-native: 3d05433cd2c84cbbcdfcd917dabaf3f8dfd919ea
+  unflow-react-native: 7c780022fd669822aa1f3aa9ad8c776457812e5e
   Yoga: 5cbf25add73edb290e1067017690f7ebf56c5468
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unflow-react-native",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Tired of building the same simple screens over and over again? Empower your product team to create and ship content using the Unflow mobile SDK.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
### Fixed
- An issue where iOS builds wouldn't compile due to a missing `Task`.

Draft release:
https://github.com/unflowhq/unflow-react-native-sdk/releases/edit/untagged-6cc7868f5abdddfddeb6