### PR TITLE
Refactor Swift bridge for tracking metadata

### DIFF
--- a/UnflowMetadataBridge.swift
+++ b/UnflowMetadataBridge.swift
@@ -1,0 +1,36 @@
+//
+//  UnflowMetadataBridge.swift
+//  unflow-react-native
+//
+//  Created by Alex Logan on 12/10/2022.
+//
+
+import Foundation
+import UnflowUI
+
+struct UnflowMetadataBridge {
+    static func convert(metadata: NSDictionary) -> [String: UnflowAnalyticsValue] {
+        metadata.compactMap { (key: Any, value: Any) -> (String, UnflowAnalyticsValue)? in
+            guard let key = key as? String, let value = convertToAnalyticsValue(value) else { return nil }
+            return (key, value)
+        }.reduce(into: [:], { $0[$1.0] = $1.1 })
+    }
+
+    private static func convertToAnalyticsValue(_ value: Any) -> UnflowAnalyticsValue? {
+        if let analyticsValue = value as? UnflowAnalyticsValue {
+            return analyticsValue
+        } else if let numberValue = value as? NSNumber {
+            return numberValue.doubleValue
+        } else if let stringValue = value as? NSString {
+            return String(stringValue)
+        } else if let date = value as? NSDate {
+            return date as Date
+        } else if let array = value as? NSArray {
+            return array.compactMap(convertToAnalyticsValue)
+        } else if let dictionary = value as? NSDictionary {
+            return convert(metadata: dictionary)
+        }
+        print("Unflow: Parameter of type \(type(of: value)) could not be stored in event metadata")
+        return nil
+    }
+}

--- a/ios/Unflow.swift
+++ b/ios/Unflow.swift
@@ -159,9 +159,13 @@ class Unflow: NSObject {
     func trackEvent(eventName: String, metadata: NSDictionary) -> Void {
         if #available(iOS 13.0, *) {
             do {
-                let attributes = try EventMetadata(from: metadata)
-                UnflowSDK.client.trackEvent(eventName, attributes: attributes)
-            } catch {}
+                // Simply checks for valid JSON
+                _ = try EventMetadata(from: metadata)
+                let bridgedAttributes = UnflowMetadataBridge.convert(metadata: metadata)
+                UnflowSDK.client.trackEvent(eventName, attributes: bridgedAttributes)
+            } catch {
+                print("Unflow: Unable to track event")
+            }
         }
     }
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -103,8 +103,11 @@ export type UnflowOpenerViewType = {
 };
 
 type AttributeValue = string | number | boolean;
-type AttributeObject = { [key: string] : AttributeValue | AttributeValue[] }
-type MetadataAttributeValue = AttributeValue | AttributeValue[] | AttributeObject[];
+type AttributeObject = { [key: string]: AttributeValue | AttributeValue[] };
+type MetadataAttributeValue =
+  | AttributeValue
+  | AttributeValue[]
+  | AttributeObject[];
 
 type Metadata = {
   [key: string]: MetadataAttributeValue;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -102,6 +102,14 @@ export type UnflowOpenerViewType = {
   }) => {};
 };
 
+type AttributeValue = string | number | boolean;
+type AttributeObject = { [key: string] : AttributeValue | AttributeValue[] }
+type MetadataAttributeValue = AttributeValue | AttributeValue[] | AttributeObject[];
+
+type Metadata = {
+  [key: string]: MetadataAttributeValue;
+};
+
 type Font =
   | string
   | {
@@ -124,7 +132,7 @@ export type UnflowType = {
     openerSubtitle?: Font;
   }): null;
   openScreen(screenId: number): null;
-  trackEvent(eventName: string, metadata: { [key: string]: any }): null;
+  trackEvent(eventName: string, metadata: Metadata): null;
   deregisterToken(): null;
   addAnalyticsListener: (
     callback: (event: UnflowEvent) => void


### PR DESCRIPTION
The Swift bridge currently fails to provide metadata to the iOS SDK as the types provided are Objective-C types. This PR refactors the `trackEvent` call within the Swift bridge to turn the types into their Swift equivalents.

Adds a tighter type requirement to match the types that we support inside the native SDK's.

### Sample

```json
const metadataExample = {
  "one": "one value",
  "two": 2,
  "three": [1,2,3],
  "four": ["one","two","three"],
  "five": [{ "fiveone": "one" }]
} as Metadata
```