### PR TITLE
Fix a bug with empty string subtitles

### DIFF
--- a/src/default-opener-view.tsx
+++ b/src/default-opener-view.tsx
@@ -105,7 +105,7 @@ const DefaultCard: React.FC<DefaultCardProps> = ({
     {opener.imageURL && <Thumnail uri={opener.imageURL} />}
     <View style={styles.content}>
       <Text style={[styles.title, titleStyles[style]]}>{opener?.title}</Text>
-      { opener.subtitle != undefined && opener?.subtitle != "" && (
+      {opener.subtitle !== undefined && opener?.subtitle !== '' && (
         <Text
           style={[styles.subtitle, subtitleStyles[style]]}
           numberOfLines={2}

--- a/src/default-opener-view.tsx
+++ b/src/default-opener-view.tsx
@@ -105,7 +105,7 @@ const DefaultCard: React.FC<DefaultCardProps> = ({
     {opener.imageURL && <Thumnail uri={opener.imageURL} />}
     <View style={styles.content}>
       <Text style={[styles.title, titleStyles[style]]}>{opener?.title}</Text>
-      {opener.subtitle && (
+      { opener.subtitle != undefined && opener?.subtitle != "" && (
         <Text
           style={[styles.subtitle, subtitleStyles[style]]}
           numberOfLines={2}


### PR DESCRIPTION
Inside the example app an empty string was causing a bug with the renderer. This adjusts the null check to also check for empty string explicitly. 