### PR TITLE
v1.14.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -123,5 +123,5 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:1.3.1"
-  implementation "com.unflow:unflow-ui:1.13.1"
+  implementation "com.unflow:unflow-ui:1.14.0"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -352,10 +352,10 @@ PODS:
     - React-RCTImage
   - RNSVG (12.3.0):
     - React-Core
-  - Unflow (1.13.0-swift-5.6)
-  - unflow-react-native (1.13.1):
+  - Unflow (1.14.0-swift-5.6)
+  - unflow-react-native (1.14.0):
     - React-Core
-    - Unflow (= 1.13.0-swift-5.6)
+    - Unflow (= 1.14.0-swift-5.6)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -562,8 +562,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 6e757e487a4834e7280e98e9bac66d2d9c575e9c
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Unflow: 085a89a706e4ea0b484388f87ae3af43f19ff91a
-  unflow-react-native: 21deab6f762c048e48bad8fc574813c6b5fa56af
+  Unflow: 1872972d53c3051f0afd8735f1d92bb4b7fd9d79
+  unflow-react-native: 7e06aa68f3f6292c5204ad02a3d1d3f4cd15c38a
   Yoga: 5cbf25add73edb290e1067017690f7ebf56c5468
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unflow-react-native",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Tired of building the same simple screens over and over again? Empower your product team to create and ship content using the Unflow mobile SDK.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -29,7 +29,7 @@
     "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
-    "pods": "cd example && pod-install --quiet",
+    "pods": "cd example && pod-install --quiet --repo-update",
     "bootstrap": "yarn example && yarn && yarn pods"
   },
   "keywords": [

--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Unflow", "1.13.0-swift-5.6"
+  s.dependency "Unflow", "1.14.0-swift-5.6"
 end


### PR DESCRIPTION
### Changes
- When you have a page with a single select question block, it will no longer automatically close after selection.
- When you have a carousel with a single select question block, it will no longer automatically push the next page after selection.
- The pause function will now also prevent screens from push notifications from showing. When you pause the SDK and a user opens a push, it will only show the screen after you've called resume.
- When a user selects a button with a deeplink, we'll close our actvity/view controller for you.

### Added
- You can now configure if a question requires a response or not.

### Fixed
- The pause function will no longer stop manual calls to `openScreen` from opening.
- On Android, we've improved the layouts for our visual screens to hug most of the time, and flex when it would look better.
- When closing a page via a link, the animation has been corrected.
