### PR TITLE
v1.14.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -123,5 +123,5 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:1.3.1"
-  implementation "com.unflow:unflow-ui:1.14.0"
+  implementation "com.unflow:unflow-ui:1.14.1"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -352,10 +352,10 @@ PODS:
     - React-RCTImage
   - RNSVG (12.3.0):
     - React-Core
-  - Unflow (1.14.0-swift-5.6)
-  - unflow-react-native (1.14.0):
+  - Unflow (1.14.1-swift-5.6)
+  - unflow-react-native (1.14.1):
     - React-Core
-    - Unflow (= 1.14.0-swift-5.6)
+    - Unflow (= 1.14.1-swift-5.6)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -562,8 +562,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 6e757e487a4834e7280e98e9bac66d2d9c575e9c
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Unflow: 1872972d53c3051f0afd8735f1d92bb4b7fd9d79
-  unflow-react-native: 7e06aa68f3f6292c5204ad02a3d1d3f4cd15c38a
+  Unflow: e5ab27076c7859439995b6a6ee7b2d98ff386046
+  unflow-react-native: 871e0a0356e7a41cd45601d41071f1873d9c507f
   Yoga: 5cbf25add73edb290e1067017690f7ebf56c5468
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unflow-react-native",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Tired of building the same simple screens over and over again? Empower your product team to create and ship content using the Unflow mobile SDK.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Unflow", "1.14.0-swift-5.6"
+  s.dependency "Unflow", "1.14.1-swift-5.6"
 end


### PR DESCRIPTION
This SDK update makes a change to how images are sized on our articles. We used to try to squish the image around to make sure that it looks good, but we realised that it's actually better to just be consistent. 

With that in mind, we've now switched all of our articles screens to use a 4:3 image up top, which will be sized based on the width of the device. Your image will be center cropped.

For a helping hand with visualising this, please use our [Figma Template](https://www.figma.com/file/0AKDDiE9CitSz7BIvoKAZp/Unflow-Image-Editor?node-id=909%3A75&t=ikGwfZjHPOHuyJCU-1).

Your existing articles should generally look better out of the box, with a much closer match to the dashboard, but we'd reccomend giving them a once over to make sure they look great.

## Changes
- Article images are now 4/3 always, regardless of the content of the image