### PR TITLE
v1.15.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -123,5 +123,5 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:1.3.1"
-  implementation "com.unflow:unflow-ui:1.15.0"
+  implementation "com.unflow:unflow-ui:1.15.1"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -352,10 +352,10 @@ PODS:
     - React-RCTImage
   - RNSVG (12.3.0):
     - React-Core
-  - Unflow (1.15.0-swift-5.6)
-  - unflow-react-native (1.15.0):
+  - Unflow (1.15.1-swift-5.6)
+  - unflow-react-native (1.15.1):
     - React-Core
-    - Unflow (= 1.15.0-swift-5.6)
+    - Unflow (= 1.15.1-swift-5.6)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -562,8 +562,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 6e757e487a4834e7280e98e9bac66d2d9c575e9c
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Unflow: cfb8a107a7df1b24ad26a87d84361322388037fb
-  unflow-react-native: 679d2ec0f8a1bf65db8d62f428fd53a20c4d4b06
+  Unflow: 43d3003a1428c7f60438f6396610bf8b17025ceb
+  unflow-react-native: 503c69119fdbdd2463b8a39549912060e271feab
   Yoga: 5cbf25add73edb290e1067017690f7ebf56c5468
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unflow-react-native",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Tired of building the same simple screens over and over again? Empower your product team to create and ship content using the Unflow mobile SDK.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/unflow-react-native.podspec
+++ b/unflow-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Unflow", "1.15.0-swift-5.6"
+  s.dependency "Unflow", "1.15.1-swift-5.6"
 end


### PR DESCRIPTION
# iOS 

## Fixes
- Close actions will now behave as expected in Flows.
- Screens with their completion actions empty will now allow normal logic to take place.
- Stops a bug where blocks could sometimes be re-ordered.
- When you use the `pause` function, and provide a push notification, it will now only show the content when you call resume.

# Android

## Fixes
- Close actions will now behave as expected in Flows.
- Screens with their completion actions empty will now allow normal logic to take place.
- Stops a bug where blocks could sometimes be re-ordered.